### PR TITLE
fix: replace dependabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS
+# This file defines who is responsible for code in this repository.
+# These users will be automatically requested for review when someone opens a pull request.
+# This includes pull requests opened by Dependabot.
+
+# Default owner for everything in the repo
+* @yk-lab
+
+# GitHub Actions workflows
+.github/ @yk-lab
+
+# Documentation
+*.md @yk-lab
+docs/ @yk-lab
+
+# Package files
+package.json @yk-lab
+pnpm-lock.yaml @yk-lab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       time: "06:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
-    reviewers:
-      - yk-lab
     labels:
       - dependencies
       - npm
@@ -32,8 +30,6 @@ updates:
       time: "06:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
-    reviewers:
-      - yk-lab
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
## Description

  - Remove deprecated reviewers field from dependabot.yml
  - Add .github/CODEOWNERS file for automatic review assignments

  The reviewers field in dependabot.yml is being deprecated.
  Using CODEOWNERS is the recommended approach for assigning
  reviewers to Dependabot PRs going forward.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation update
- [x] Code refactoring

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] `pnpm test` - All tests pass
- [ ] `pnpm lint` - No linting errors
- [ ] Manual testing with MCP client

**Test Configuration**:

- Node.js version:
- OS:
- MCP client:

## Additional Notes

Add any additional notes or screenshots about the pull request here.
