### PR TITLE
docs: add JSDoc documentation to public APIs

### DIFF
--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -9,6 +9,21 @@ const pkg = require('../../../package.json') as {
   version: string;
 };
 
+/**
+ * Creates a new MCP server instance configured for text2slack.
+ *
+ * The server is initialized with the package name and version from package.json,
+ * and configured with tools capability.
+ *
+ * @returns A new McpServer instance ready for tool registration
+ *
+ * @example
+ * ```typescript
+ * const server = createMcpServer();
+ * registerSendToSlackTool(server, slackClient);
+ * await startServer(server);
+ * ```
+ */
 export function createMcpServer(): McpServer {
   return new McpServer(
     {
@@ -24,7 +39,22 @@ export function createMcpServer(): McpServer {
 }
 
 /**
- * Gracefully shutdown the MCP server
+ * Gracefully shuts down the MCP server.
+ *
+ * Closes the server connection and logs the shutdown status.
+ * If an error occurs during shutdown, it is logged and re-thrown.
+ *
+ * @param server - The MCP server instance to shut down
+ * @throws {Error} If the server fails to close properly
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await shutdownServer(server);
+ * } catch (error) {
+ *   console.error('Shutdown failed:', error);
+ * }
+ * ```
  */
 export async function shutdownServer(server: McpServer): Promise<void> {
   console.error('Shutting down MCP server...');
@@ -48,7 +78,24 @@ export function _resetSignalHandlersForTesting(): void {
 }
 
 /**
- * Setup signal handlers for graceful shutdown
+ * Sets up signal handlers for graceful shutdown.
+ *
+ * Registers handlers for SIGINT and SIGTERM signals to gracefully
+ * shut down the server. If a second signal is received during shutdown,
+ * the process exits immediately with code 1.
+ *
+ * This function is idempotent - calling it multiple times will only
+ * register the handlers once.
+ *
+ * @param server - The MCP server instance to manage
+ * @param onShutdown - Optional callback executed after successful shutdown
+ *
+ * @example
+ * ```typescript
+ * setupSignalHandlers(server, () => {
+ *   console.log('Cleanup complete');
+ * });
+ * ```
  */
 export function setupSignalHandlers(
   server: McpServer,
@@ -89,7 +136,28 @@ export function setupSignalHandlers(
 }
 
 /**
- * Start the MCP server with signal handling and error recovery
+ * Starts the MCP server with signal handling and error recovery.
+ *
+ * This function:
+ * 1. Sets up SIGINT/SIGTERM signal handlers for graceful shutdown
+ * 2. Creates a stdio transport and connects the server
+ * 3. Handles startup errors by attempting cleanup before re-throwing
+ *
+ * @param server - The MCP server instance to start
+ * @throws {Error} If the server fails to start or connect
+ *
+ * @example
+ * ```typescript
+ * const server = createMcpServer();
+ * registerSendToSlackTool(server, slackClient);
+ *
+ * try {
+ *   await startServer(server);
+ * } catch (error) {
+ *   console.error('Failed to start server:', error);
+ *   process.exit(1);
+ * }
+ * ```
  */
 export async function startServer(server: McpServer): Promise<void> {
   // Setup signal handlers before starting

--- a/src/services/slack-client.ts
+++ b/src/services/slack-client.ts
@@ -1,18 +1,58 @@
+/**
+ * Result of sending a message to Slack.
+ */
 export interface SendMessageResult {
+  /** Whether the message was sent successfully */
   success: boolean;
+  /** The message that was sent */
   message: string;
 }
 
+/**
+ * Configuration options for the SlackClient.
+ */
 export interface SlackClientOptions {
+  /**
+   * Timeout in milliseconds for the Slack API request.
+   * @default 30000
+   */
   timeoutMs?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
 
+/**
+ * Client for sending messages to Slack via Incoming Webhooks.
+ *
+ * @example
+ * ```typescript
+ * const client = new SlackClient('https://hooks.slack.com/services/...');
+ * const result = await client.sendMessage('Hello, Slack!');
+ * console.log(result.success); // true
+ * ```
+ */
 export class SlackClient {
   private readonly webhookUrl: string;
   private readonly timeoutMs: number;
 
+  /**
+   * Creates a new Slack client instance.
+   *
+   * @param webhookUrl - The Slack Incoming Webhook URL
+   * @param options - Optional configuration options
+   * @throws {Error} If webhook URL is not provided
+   *
+   * @example
+   * ```typescript
+   * // Basic usage
+   * const client = new SlackClient('https://hooks.slack.com/services/...');
+   *
+   * // With custom timeout
+   * const client = new SlackClient('https://hooks.slack.com/services/...', {
+   *   timeoutMs: 10000,
+   * });
+   * ```
+   */
   constructor(webhookUrl: string, options: SlackClientOptions = {}) {
     if (!webhookUrl) {
       throw new Error('Slack webhook URL is required');
@@ -21,6 +61,22 @@ export class SlackClient {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
+  /**
+   * Sends a text message to Slack.
+   *
+   * @param message - The message text to send
+   * @returns Promise resolving to the send result
+   * @throws {Error} If message is empty or not a string
+   * @throws {Error} If the Slack API request fails
+   * @throws {Error} If the request times out
+   *
+   * @example
+   * ```typescript
+   * const result = await client.sendMessage('Hello!');
+   * console.log(result.success); // true
+   * console.log(result.message); // 'Hello!'
+   * ```
+   */
   async sendMessage(message: string): Promise<SendMessageResult> {
     if (!message || typeof message !== 'string') {
       throw new Error('Message must be a non-empty string');

--- a/src/tools/send-to-slack.ts
+++ b/src/tools/send-to-slack.ts
@@ -3,16 +3,38 @@ import { z } from 'zod/v3';
 import type { SlackClient } from '../services/slack-client.js';
 
 /**
- * Zod schema for the send_to_slack tool input
+ * Zod schema for the send_to_slack tool input.
+ * Used for validating tool arguments in the MCP protocol.
  */
 const SendToSlackArgsSchema = z.object({
   message: z.string().describe('The message to send to Slack'),
 });
 
+/**
+ * Type definition for the send_to_slack tool arguments.
+ * Inferred from the Zod schema.
+ */
 export type SendToSlackArgs = z.infer<typeof SendToSlackArgsSchema>;
 
 /**
- * Register the send_to_slack tool with the MCP server
+ * Registers the `send_to_slack` tool with the MCP server.
+ *
+ * This tool allows AI assistants to send text messages to a configured
+ * Slack channel via Incoming Webhooks.
+ *
+ * @param server - The MCP server instance to register the tool with
+ * @param slackClient - The Slack client instance for sending messages
+ *
+ * @example
+ * ```typescript
+ * import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+ * import { SlackClient } from '../services/slack-client.js';
+ *
+ * const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+ * const slackClient = new SlackClient('https://hooks.slack.com/...');
+ *
+ * registerSendToSlackTool(server, slackClient);
+ * ```
  */
 export function registerSendToSlackTool(
   server: McpServer,


### PR DESCRIPTION
## Summary

公開 API に包括的な JSDoc ドキュメントを追加し、IDE でのオートコンプリートと開発体験を向上させます。

### Changes

**src/services/slack-client.ts**
- `SendMessageResult` interface にドキュメント追加
- `SlackClientOptions` interface にドキュメント追加
- `SlackClient` class と全メソッドにドキュメント追加

**src/tools/send-to-slack.ts**
- `SendToSlackArgsSchema` にドキュメント追加
- `SendToSlackArgs` type にドキュメント追加
- `registerSendToSlackTool` function にドキュメント追加

**src/server/mcp-server.ts**
- `createMcpServer` function にドキュメント追加
- `shutdownServer` function にドキュメント追加
- `setupSignalHandlers` function にドキュメント追加
- `startServer` function にドキュメント追加

### Documentation Features

各ドキュメントには以下を含みます：
- 関数/クラス/インターフェースの説明
- `@param` タグでパラメータ説明
- `@returns` タグで戻り値説明
- `@throws` タグでエラー条件
- `@example` タグでコードサンプル

## Acceptance Criteria

- [x] すべての公開クラス・関数に JSDoc を追加
- [x] パラメータと戻り値の説明を記載
- [x] `@throws` でエラー条件を文書化
- [x] `@example` で使用例を追加

## Test Plan

- [x] `pnpm lint` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス（31 tests）

Closes #90