### PR TITLE
feat(validation): add comprehensive webhook URL and message validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,14 @@
 # このファイルを .env にコピーして使用してください
 # cp .env.example .env
 
-# Slack Incoming Webhook URL (必須)
-# Webhook URL の取得方法: https://api.slack.com/messaging/webhooks
+# Webhook URL (必須)
+# Slack, Discord, Mattermost などの Incoming Webhook URL を設定
+# 注意: HTTPS必須（localhost/127.0.0.1 のみ開発用にHTTP許可）
+#
+# 各サービスの Webhook URL 取得方法:
+#   Slack: https://api.slack.com/messaging/webhooks
+#   Discord: https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
+#   Mattermost: https://docs.mattermost.com/developer/webhooks-incoming.html
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
 # デバッグモード (オプション)

--- a/cli.ts
+++ b/cli.ts
@@ -3,11 +3,29 @@ import 'dotenv/config';
 import { createMcpServer, startServer } from './src/server/mcp-server.js';
 import { SlackClient } from './src/services/slack-client.js';
 import { registerSendToSlackTool } from './src/tools/send-to-slack.js';
+import { ConfigError, validateWebhookUrl } from './src/utils/validation.js';
 
 // Validate environment variable at startup
 const webhookUrl = process.env.SLACK_WEBHOOK_URL;
 if (!webhookUrl) {
   console.error('Error: SLACK_WEBHOOK_URL environment variable is not set');
+  console.error('');
+  console.error('Please set the webhook URL for your messaging service:');
+  console.error('  - Slack: https://hooks.slack.com/services/...');
+  console.error('  - Discord: https://discord.com/api/webhooks/...');
+  console.error('  - Mattermost: https://your-server.com/hooks/...');
+  process.exit(1);
+}
+
+// Validate webhook URL format
+try {
+  validateWebhookUrl(webhookUrl);
+} catch (error) {
+  if (error instanceof ConfigError) {
+    console.error(`Error: ${error.message}`);
+  } else {
+    console.error('Error: Invalid webhook URL configuration', error);
+  }
   process.exit(1);
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,129 @@
+/**
+ * Validation utilities for webhook URLs and messages.
+ * @module
+ */
+
+/**
+ * Error thrown when configuration validation fails.
+ */
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigError';
+  }
+}
+
+/**
+ * Error thrown when message validation fails.
+ */
+export class MessageValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MessageValidationError';
+  }
+}
+
+/**
+ * Default maximum message length (Slack's limit).
+ */
+export const DEFAULT_MAX_MESSAGE_LENGTH = 4000;
+
+/**
+ * Checks if a hostname is a localhost address.
+ * Supports both IPv4 (127.0.0.1) and IPv6 (::1) loopback addresses.
+ *
+ * @param hostname - The hostname to check
+ * @returns `true` if the hostname is localhost, `false` otherwise
+ */
+function isLocalhostAddress(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  );
+}
+
+/**
+ * Validates a webhook URL for format and security requirements.
+ *
+ * Requirements:
+ * - Must be a valid URL (parseable by URL constructor)
+ * - Must use HTTPS protocol (HTTP allowed only for localhost/127.0.0.1)
+ * - No domain restrictions (supports Slack, Discord, Mattermost, etc.)
+ *
+ * @param url - The webhook URL to validate
+ * @throws {ConfigError} If the URL is empty, invalid, or uses non-HTTPS protocol
+ *
+ * @example
+ * ```typescript
+ * // Valid URLs
+ * validateWebhookUrl('https://hooks.slack.com/services/...');
+ * validateWebhookUrl('https://discord.com/api/webhooks/...');
+ * validateWebhookUrl('https://mattermost.example.com/hooks/...');
+ * validateWebhookUrl('http://localhost:3000/webhook');  // OK for local dev
+ *
+ * // Invalid URLs throw ConfigError
+ * validateWebhookUrl('');  // 'Webhook URL is required'
+ * validateWebhookUrl('not-a-url');  // 'Webhook URL is not a valid URL'
+ * validateWebhookUrl('http://example.com');  // 'Webhook URL must use HTTPS'
+ * ```
+ */
+export function validateWebhookUrl(url: string): void {
+  if (!url) {
+    throw new ConfigError('Webhook URL is required');
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new ConfigError(
+      'Webhook URL is not a valid URL. Expected format: https://hooks.example.com/...',
+    );
+  }
+
+  // Allow HTTP only for localhost (development/testing)
+  if (parsedUrl.protocol !== 'https:') {
+    if (
+      parsedUrl.protocol === 'http:' &&
+      isLocalhostAddress(parsedUrl.hostname)
+    ) {
+      // HTTP is allowed for localhost development
+      return;
+    }
+    throw new ConfigError(
+      'Webhook URL must use HTTPS for security. HTTP is not allowed.',
+    );
+  }
+}
+
+/**
+ * Validates a message for content and length requirements.
+ *
+ * @param message - The message to validate
+ * @param maxLength - Maximum allowed message length (default: 4000 for Slack)
+ * @throws {MessageValidationError} If the message is empty or exceeds the maximum length
+ *
+ * @example
+ * ```typescript
+ * validateMessage('Hello, world!');  // OK
+ * validateMessage('');  // throws 'Message must be a non-empty string'
+ * validateMessage('x'.repeat(5000));  // throws 'Message exceeds maximum length...'
+ * validateMessage('Hello', 10);  // OK with custom max length
+ * ```
+ */
+export function validateMessage(
+  message: string,
+  maxLength: number = DEFAULT_MAX_MESSAGE_LENGTH,
+): void {
+  if (!message || typeof message !== 'string') {
+    throw new MessageValidationError('Message must be a non-empty string');
+  }
+
+  if (message.length > maxLength) {
+    throw new MessageValidationError(
+      `Message exceeds maximum length of ${maxLength} characters (got ${message.length})`,
+    );
+  }
+}

--- a/test/utils/validation.test.ts
+++ b/test/utils/validation.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ConfigError,
+  DEFAULT_MAX_MESSAGE_LENGTH,
+  MessageValidationError,
+  validateMessage,
+  validateWebhookUrl,
+} from '../../src/utils/validation.js';
+
+describe('validateWebhookUrl', () => {
+  describe('valid URLs', () => {
+    it('should accept valid Slack webhook URL', () => {
+      expect(() =>
+        validateWebhookUrl('https://hooks.slack.com/services/T00/B00/xxx'),
+      ).not.toThrow();
+    });
+
+    it('should accept valid Discord webhook URL', () => {
+      expect(() =>
+        validateWebhookUrl('https://discord.com/api/webhooks/123/abc'),
+      ).not.toThrow();
+    });
+
+    it('should accept valid Mattermost webhook URL', () => {
+      expect(() =>
+        validateWebhookUrl('https://mattermost.example.com/hooks/xxx'),
+      ).not.toThrow();
+    });
+
+    it('should accept any HTTPS URL (no domain restriction)', () => {
+      expect(() =>
+        validateWebhookUrl(
+          'https://custom-service.internal.company.com/webhook',
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe('empty URL', () => {
+    it('should throw ConfigError for empty string', () => {
+      expect(() => validateWebhookUrl('')).toThrow(ConfigError);
+      expect(() => validateWebhookUrl('')).toThrow('Webhook URL is required');
+    });
+
+    it('should throw ConfigError for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => validateWebhookUrl(undefined)).toThrow(ConfigError);
+    });
+
+    it('should throw ConfigError for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => validateWebhookUrl(null)).toThrow(ConfigError);
+    });
+  });
+
+  describe('invalid URL format', () => {
+    it('should throw ConfigError for non-URL string', () => {
+      expect(() => validateWebhookUrl('not-a-url')).toThrow(ConfigError);
+      expect(() => validateWebhookUrl('not-a-url')).toThrow(
+        'Webhook URL is not a valid URL',
+      );
+    });
+
+    it('should throw ConfigError for malformed URL', () => {
+      expect(() => validateWebhookUrl('http://')).toThrow(ConfigError);
+    });
+
+    it('should throw ConfigError for URL without protocol', () => {
+      expect(() => validateWebhookUrl('hooks.slack.com/services/xxx')).toThrow(
+        ConfigError,
+      );
+    });
+  });
+
+  describe('protocol validation', () => {
+    it('should throw ConfigError for HTTP URL (non-localhost)', () => {
+      expect(() =>
+        validateWebhookUrl('http://hooks.slack.com/services/xxx'),
+      ).toThrow(ConfigError);
+      expect(() =>
+        validateWebhookUrl('http://hooks.slack.com/services/xxx'),
+      ).toThrow('Webhook URL must use HTTPS');
+    });
+
+    it('should allow HTTP for localhost (development)', () => {
+      expect(() =>
+        validateWebhookUrl('http://localhost:3000/webhook'),
+      ).not.toThrow();
+    });
+
+    it('should allow HTTP for 127.0.0.1 (development)', () => {
+      expect(() =>
+        validateWebhookUrl('http://127.0.0.1:8080/webhook'),
+      ).not.toThrow();
+    });
+
+    it('should allow HTTP for IPv6 localhost [::1] (development)', () => {
+      expect(() =>
+        validateWebhookUrl('http://[::1]:8080/webhook'),
+      ).not.toThrow();
+    });
+
+    it('should throw ConfigError for FTP URL', () => {
+      expect(() => validateWebhookUrl('ftp://example.com/file')).toThrow(
+        ConfigError,
+      );
+      expect(() => validateWebhookUrl('ftp://example.com/file')).toThrow(
+        'Webhook URL must use HTTPS',
+      );
+    });
+
+    it('should throw ConfigError for file URL', () => {
+      expect(() => validateWebhookUrl('file:///etc/passwd')).toThrow(
+        ConfigError,
+      );
+    });
+  });
+
+  describe('ConfigError properties', () => {
+    it('should have correct error name', () => {
+      try {
+        validateWebhookUrl('');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ConfigError);
+        expect((error as ConfigError).name).toBe('ConfigError');
+      }
+    });
+  });
+});
+
+describe('validateMessage', () => {
+  describe('valid messages', () => {
+    it('should accept non-empty string', () => {
+      expect(() => validateMessage('Hello, world!')).not.toThrow();
+    });
+
+    it('should accept message at exactly max length', () => {
+      const message = 'x'.repeat(DEFAULT_MAX_MESSAGE_LENGTH);
+      expect(() => validateMessage(message)).not.toThrow();
+    });
+
+    it('should accept message with custom max length', () => {
+      const message = 'x'.repeat(100);
+      expect(() => validateMessage(message, 100)).not.toThrow();
+    });
+
+    it('should accept whitespace-only message', () => {
+      // Whitespace is technically a non-empty string
+      expect(() => validateMessage('   ')).not.toThrow();
+    });
+  });
+
+  describe('empty message', () => {
+    it('should throw MessageValidationError for empty string', () => {
+      expect(() => validateMessage('')).toThrow(MessageValidationError);
+      expect(() => validateMessage('')).toThrow(
+        'Message must be a non-empty string',
+      );
+    });
+
+    it('should throw MessageValidationError for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => validateMessage(undefined)).toThrow(MessageValidationError);
+    });
+
+    it('should throw MessageValidationError for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => validateMessage(null)).toThrow(MessageValidationError);
+    });
+
+    it('should throw MessageValidationError for non-string types', () => {
+      // @ts-expect-error Testing invalid input
+      expect(() => validateMessage(123)).toThrow(MessageValidationError);
+      // @ts-expect-error Testing invalid input
+      expect(() => validateMessage({})).toThrow(MessageValidationError);
+      // @ts-expect-error Testing invalid input
+      expect(() => validateMessage([])).toThrow(MessageValidationError);
+    });
+  });
+
+  describe('message length validation', () => {
+    it('should throw MessageValidationError for message exceeding default max length', () => {
+      const message = 'x'.repeat(DEFAULT_MAX_MESSAGE_LENGTH + 1);
+      expect(() => validateMessage(message)).toThrow(MessageValidationError);
+      expect(() => validateMessage(message)).toThrow(
+        `Message exceeds maximum length of ${DEFAULT_MAX_MESSAGE_LENGTH} characters`,
+      );
+    });
+
+    it('should include actual message length in error', () => {
+      const length = DEFAULT_MAX_MESSAGE_LENGTH + 100;
+      const message = 'x'.repeat(length);
+      expect(() => validateMessage(message)).toThrow(`got ${length}`);
+    });
+
+    it('should respect custom max length (Discord limit)', () => {
+      const discordLimit = 2000;
+      const message = 'x'.repeat(2001);
+      expect(() => validateMessage(message, discordLimit)).toThrow(
+        MessageValidationError,
+      );
+      expect(() => validateMessage(message, discordLimit)).toThrow(
+        `Message exceeds maximum length of ${discordLimit} characters`,
+      );
+    });
+
+    it('should accept message just under max length', () => {
+      const message = 'x'.repeat(DEFAULT_MAX_MESSAGE_LENGTH - 1);
+      expect(() => validateMessage(message)).not.toThrow();
+    });
+  });
+
+  describe('MessageValidationError properties', () => {
+    it('should have correct error name', () => {
+      try {
+        validateMessage('');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MessageValidationError);
+        expect((error as MessageValidationError).name).toBe(
+          'MessageValidationError',
+        );
+      }
+    });
+  });
+});
+
+describe('DEFAULT_MAX_MESSAGE_LENGTH', () => {
+  it('should be 4000 (Slack limit)', () => {
+    expect(DEFAULT_MAX_MESSAGE_LENGTH).toBe(4000);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ConfigError` and `MessageValidationError` custom error classes for better error handling
- Validate webhook URL format and HTTPS requirement (with localhost/IPv6 exception for development)
- Validate message content and configurable max length (default: 4000 for Slack, 2000 for Discord)
- Support multiple webhook services (Slack, Discord, Mattermost) without strict domain checking
- Add startup validation in `cli.ts` with helpful multi-service error messages

## Changes

### New Files
- `src/utils/validation.ts` - Validation utilities module
- `test/utils/validation.test.ts` - Comprehensive tests (31 tests)

### Modified Files
- `cli.ts` - Add startup URL validation with helpful error messages
- `src/services/slack-client.ts` - Use validation functions, add `maxMessageLength` option
- `test/services/slack-client.test.ts` - Add validation tests
- `.env.example` - Update documentation for multi-service support

## Test Plan

- [x] All 107 tests pass
- [x] 100% line coverage maintained
- [x] Lint/TypeScript checks pass
- [x] CodeRabbit review passed (IPv6 support added)

Closes #80, closes #85